### PR TITLE
Publish t2iapi to pypi

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-python
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -73,7 +73,7 @@ jobs:
           name: html_unit_test
           path: unittest_results/*.html
           retention-days: 1
-  deploy-github-packages:
+  deploy-pypi-packages:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     needs: run-tests-python

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -5,9 +5,11 @@ on:
   push: # Apply to all branches
 
 env:
+  PYTHON_VERSION: 3.8.10
   PIP_VERSION: 22.0.4
   WHEEL_VERSION: 0.37.0
   HTML_TEST_RUNNER_VERSION: 1.2.1
+  TWINE_VERSION: 4.0.1
 
 jobs:
   build-python:
@@ -25,7 +27,7 @@ jobs:
           version: ${{ env.PYTHON_PROTOC_VERSION }}
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8.10'
+          python-version: ${PYTHON_VERSION}
       - name: Install python dependencies
         run: python -m pip install --no-cache-dir --upgrade pip==${PIP_VERSION} wheel==${WHEEL_VERSION}
       - name: Protobuf compile
@@ -47,19 +49,19 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8.10'
+          python-version: ${PYTHON_VERSION}
       - name: Download t2iapi wheel artifact
         uses: actions/download-artifact@v3
         with:
           name: dist
       - name: Install t2iapi package
-        run: python3.8 -m pip install t2iapi*.whl
+        run: python -m pip install t2iapi*.whl
       - name: pip freeze
-        run: python3.8 -m pip freeze --no-cache-dir > pip_freeze.txt
+        run: python -m pip freeze --no-cache-dir > pip_freeze.txt
       - name: install html test runner
-        run: python3.8 -m pip install html-testRunner==${HTML_TEST_RUNNER_VERSION}
+        run: python -m pip install html-testRunner==${HTML_TEST_RUNNER_VERSION}
       - name: run unit tests
-        run: python3.8 ./tests/python/html_report.py
+        run: python ./tests/python/html_report.py
       - name: Archive freeze information
         uses: actions/upload-artifact@v3
         with:
@@ -72,3 +74,18 @@ jobs:
           name: html_unit_test
           path: unittest_results/*.html
           retention-days: 1
+  deploy-github-packages:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    needs: run-tests-python
+    steps:
+      - name: Download t2iapi wheel artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist/
+      - name: Publish t2iapi to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -87,5 +87,4 @@ jobs:
       - name: Publish t2iapi to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -9,7 +9,6 @@ env:
   PIP_VERSION: 22.0.4
   WHEEL_VERSION: 0.37.0
   HTML_TEST_RUNNER_VERSION: 1.2.1
-  TWINE_VERSION: 4.0.1
 
 jobs:
   build-python:

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -27,7 +27,7 @@ jobs:
           version: ${{ env.PYTHON_PROTOC_VERSION }}
       - uses: actions/setup-python@v4
         with:
-          python-version: ${PYTHON_VERSION}
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install python dependencies
         run: python -m pip install --no-cache-dir --upgrade pip==${PIP_VERSION} wheel==${WHEEL_VERSION}
       - name: Protobuf compile
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4
         with:
-          python-version: ${PYTHON_VERSION}
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Download t2iapi wheel artifact
         uses: actions/download-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -16,17 +16,19 @@ application.
 
 #### Python
 
-t2iapi wheels can be built locally using the following steps:
+t2iapi wheels can be built locally using the following steps using python version 3.8.10:
 
+Note, this requires `protoc` and `python` to be in your `PATH`.
 ```shell
 cd python
 ./build_protobuf.sh
+python -m pip install wheel==0.37.0
 python setup.py bdist_wheel
 ```
 
 Wheels will be available in `t2iapi/python/dist`.
 
-Note that this requires protoc to be in your `PATH`.
+
 
 
 #### Java

--- a/python/build_protobuf.sh
+++ b/python/build_protobuf.sh
@@ -2,7 +2,7 @@
 
 source ../config/versions.txt
 
-python -m pip install "grpcio==$PYTHON_GRPC_VERSION" "grpcio-tools==$PYTHON_GRPC_VERSION" "wheel==0.37.0" || exit 1
+python -m pip install "grpcio==$PYTHON_GRPC_VERSION" "grpcio-tools==$PYTHON_GRPC_VERSION" || exit 1
 ./clean.sh
 
 echo "Generating model and service data"

--- a/python/build_protobuf.sh
+++ b/python/build_protobuf.sh
@@ -2,8 +2,8 @@
 
 source ../config/versions.txt
 
-python3.8 -m pip install "grpcio==$PYTHON_GRPC_VERSION" "grpcio-tools==$PYTHON_GRPC_VERSION" || exit 1
+python -m pip install "grpcio==$PYTHON_GRPC_VERSION" "grpcio-tools==$PYTHON_GRPC_VERSION" "wheel==0.37.0" || exit 1
 ./clean.sh
 
 echo "Generating model and service data"
-python3.8 -m grpc_tools.protoc -I=../src --python_out=src --grpc_python_out=src ../src/t2iapi/*.proto ../src/t2iapi/**/*.proto || exit 2
+python -m grpc_tools.protoc -I=../src --python_out=src --grpc_python_out=src ../src/t2iapi/*.proto ../src/t2iapi/**/*.proto || exit 2

--- a/python/setup.py
+++ b/python/setup.py
@@ -4,7 +4,9 @@
 # SPDX-License-Identifier: MIT
 
 import os
+
 import setuptools
+
 
 def read_config_map():
     """
@@ -12,13 +14,10 @@ def read_config_map():
 
     @return: a dictionary representing the version config
     """
-    data = {}
-    with open("../config/versions.txt") as f:
+    with open('../config/versions.txt') as f:
         lines = f.read().splitlines()
-        for line in lines:
-            key, value = line.split("=")
-            data[key] = value
-    return data
+        return dict(line.split('=') for line in lines)
+
 
 def get_build_version():
     """
@@ -27,16 +26,19 @@ def get_build_version():
 
     @return: package version
     """
-    return os.getenv('build_version', default='0.0.0')
+    package = os.getenv('BASE_PACKAGE_VERSION', default='0.0.0')
+    dev_release = f'dev{os.getenv("GITHUB_RUN_NUMBER", default=0)}'
+    return f'{package}.{dev_release}'
+
 
 config_map = read_config_map()
 
 setuptools.setup(
-    name="t2iapi",
+    name='t2iapi',
     version=get_build_version(),
-    author="T2I Team",
-    author_email="DLCDE-ODDS-T2I@draeger.com",
-    description="T2I API for device communication in test scenarios",
+    author='T2I Team',
+    author_email='DLCDE-ODDS-T2I@draeger.com',
+    description='T2I API for device communication in test scenarios',
     long_description='''
     Contains generated python files created from protobuf files.
     The protobuf files contain the specification of the serialization used to communicate information in test scenarios.
@@ -46,7 +48,8 @@ setuptools.setup(
     url='https://github.com/Draegerwerk/t2iapi',
     package_dir={'': 'src'},
     packages=setuptools.find_packages(where='src'),
-    install_requires=['protobuf==' + config_map["PYTHON_PROTOC_VERSION"], 'grpcio==' + config_map["PYTHON_GRPC_VERSION"]],
+    install_requires=['protobuf==' + config_map['PYTHON_PROTOC_VERSION'],
+                      'grpcio==' + config_map['PYTHON_GRPC_VERSION']],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python :: 3 :: Only',

--- a/python/setup.py
+++ b/python/setup.py
@@ -21,8 +21,9 @@ def read_config_map():
 
 def get_build_version():
     """
-    Get the package version from the respective environment parameter, if available.
-    Otherwise, return '0.0.0'.
+    Get the package and development release version from the respective environment parameter, if available.
+    Otherwise, return '0.0.0.dev0'.
+    Following version scheme from https://peps.python.org/pep-0440/#version-scheme
 
     @return: package version
     """

--- a/python/setup.py
+++ b/python/setup.py
@@ -28,8 +28,8 @@ def get_build_version():
     @return: package version
     """
     package = os.getenv('BASE_PACKAGE_VERSION', default='0.0.0')
-    dev_release = f'dev{os.getenv("GITHUB_RUN_NUMBER", default=0)}'
-    return f'{package}.{dev_release}'
+    dev_release_segment = f'dev{os.getenv("GITHUB_RUN_NUMBER", default=0)}'
+    return f'{package}.{dev_release_segment}'
 
 
 config_map = read_config_map()


### PR DESCRIPTION
In order to easily distribute the t2iapi pyhon package built from the protobuf sources, upload t2iapi python package to pypi.org
