### PR TITLE
Added the GetRemovableDescriptorsOfType manipulation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- manipulation GetRemovableDescriptorsOfType
+
 ### Removed
 
 - manipulation SetMetricValuesWithQualityValidity

--- a/src/t2iapi/device/device_requests.proto
+++ b/src/t2iapi/device/device_requests.proto
@@ -43,3 +43,10 @@ message ChangeMdibSequenceIdRequest {
     string descriptive_name = 1;  // descriptive name as a string which describes the trigger
                                   // for a change of the MDIB SequenceId
 }
+
+/*
+Request a filtered List of removable Descriptors.
+ */
+message GetRemovableDescriptorsOfTypeRequest {
+    DescriptorType descriptorType = 1;
+}

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -67,6 +67,17 @@ service DeviceService {
         returns (t2iapi.device.GetRemovableDescriptorsResponse);
 
     /*
+    Get all descriptor handles which can be removed and reinserted into the MDIB of the device
+    and whose descriptors are of the given type.
+    Includes handles which have been removed already and can be reinserted.
+    Handles must stay the same once reinserted into the MDIB.
+    The handles shall be representative of the devices capabilities to remove
+    descriptors (at least one of every possible kind).
+     */
+    rpc GetRemovableDescriptorsOfType (GetRemovableDescriptorsOfTypeRequest)
+        returns (t2iapi.device.GetRemovableDescriptorsResponse);
+
+    /*
     Remove a descriptor from the device MDIB.
      */
     rpc RemoveDescriptor(BasicHandleRequest) returns (BasicResponse);

--- a/src/t2iapi/device/types.proto
+++ b/src/t2iapi/device/types.proto
@@ -50,6 +50,15 @@ enum MdsOperatingMode{
     MDS_OPERATING_MODE_MAINTENANCE = 3;
 }
 
+/*
+Represents a type of Descriptor.
+Currently only filtering for MdsDescriptors is required.
+Will be extended as necessity arises.
+ */
+enum DescriptorType{
+    DESCRIPTOR_TYPE_ABSTRACT = 0;  // Base class of all Descriptors - i.e. no filtering
+    DESCRIPTOR_TYPE_MDS = 1;
+}
 
 /*
 Contains information according to an expanded xml name.


### PR DESCRIPTION
The GetRemovableDescriptorsOfType manipulation is required to get a list of removable Descriptors that are of a particular Type. Without this manipulation, a test case that needs to remove and reinsert a particular type of descriptor would have to find out the types of all removable descriptors, which is not necessarily possible, as all these descriptors might be currently removed from the MDIB.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
