### PR TITLE
Add "Ack" to SetAsActivationStateOnAndChangeAcPresenceFalse

### DIFF
--- a/src/t2iapi/alert/service.proto
+++ b/src/t2iapi/alert/service.proto
@@ -80,7 +80,7 @@ service AlertService {
     /*
     For the AlertSignal with the provided handle ensure that the following sequence appears
     - State 1
-       - pm:AlertSignalState/@Presence must be "On"
+       - pm:AlertSignalState/@Presence must be "On" or "Ack"
        - pm:AlertSignalState/@ActivationState must be "On"
        - the associated pm:AlertConditionState/@Presence must be "true"
     - State 2


### PR DESCRIPTION
Add a "Ack" as an allowed initial value of pm:AlertSignalState/@Presence in the rpc  SetAsActivationStateOnAndChangeAcPresenceFalse

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
