### PR TITLE
remove manipulation ChangeMdibSequenceId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- manipulation ChangeMdibSequenceId
 - manipulation SetUserConfirmableValue
 - manipulation SetAudioPause
 - manipulation CancelAudioPause

--- a/src/t2iapi/device/device_requests.proto
+++ b/src/t2iapi/device/device_requests.proto
@@ -37,14 +37,6 @@ message SetLanguageRequest {
 }
 
 /*
-Request a change of the MDIB SequenceId.
- */
-message ChangeMdibSequenceIdRequest {
-    string descriptive_name = 1;  // descriptive name as a string which describes the trigger
-                                  // for a change of the MDIB SequenceId
-}
-
-/*
 Request a list of removable descriptors of the given class.
  */
 message GetRemovableDescriptorsOfClassRequest {

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -84,11 +84,6 @@ service DeviceService {
      */
     rpc InsertDescriptor(BasicHandleRequest) returns (BasicResponse);
 
-    /*
-    Change of the MDIB SequenceId.
-    This manipulation of the device shall trigger a change of the MDIB SequenceId.
-     */
-    rpc ChangeMdibSequenceID (ChangeMdibSequenceIdRequest) returns (BasicResponse);
 
     /*
     Insert an mds descriptor into the device MDIB.


### PR DESCRIPTION
Remove the manipulation ChangeMdibSequenceID sice it is no longer used.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
