### PR TITLE
Added trigger any descriptor update manipulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - description for allowed combinations of InstanceIdentifier/@Root and InstanceIdentifier/@Extension
 - manipulation ComponentActivationTransition
 - type hinting for python package via [types-protobuf](https://pypi.org/project/types-protobuf/)
+- TriggerAnyDescriptorUpdate manipulation
 
 ### Changed
 
@@ -50,7 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - added IsComputerControlled manipulation for metrics
 - COMMON_PROTOC_VERSION=21.7 due to new versioning of protobuf
-- TriggerAnyDescriptorUpdate manipulation
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - added IsComputerControlled manipulation for metrics
 - COMMON_PROTOC_VERSION=21.7 due to new versioning of protobuf
+- TriggerAnyDescriptorUpdate manipulation
 
 ### Changed
 

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -99,8 +99,8 @@ service DeviceService {
     Trigger a descriptor update.
     The descriptor to update has to be chosen by the device. It is expected that this manipulation succeeds
     as long as there are descriptors than can be updated.
-    This manipulation shall result in a msg:DescriptionModificationReport message with a msg:ReportPart/@ModificationType = "Upt".
-    modification type upt.
+    This manipulation shall result in a msg:DescriptionModificationReport message containing a report part with
+    msg:ReportPart/@ModificationType = "Upt".
      */
     rpc TriggerAnyDescriptorUpdate (google.protobuf.Empty) returns (BasicResponse);
 

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -97,7 +97,7 @@ service DeviceService {
 
     /*
     Trigger a descriptor update.
-    The descriptor handle to update may be chosen by the device. It is expected that this manipulation succeeds
+    The descriptor to update has to be chosen by the device. It is expected that this manipulation succeeds
     as long as there are descriptors than can be updated.
     This manipulation shall result in a msg:DescriptionModificationReport message with a report part with
     modification type upt.

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -95,6 +95,15 @@ service DeviceService {
      */
     rpc TriggerDescriptorUpdate (BasicHandleRequest) returns (BasicResponse);
 
+    /*
+    Trigger a descriptor update.
+    The descriptor handle to update may be chosen by the device. It is expected that this manipulation succeeds
+    as long as there are descriptors than can be updated.
+    This manipulation shall result in a msg:DescriptionModificationReport message with a report part with
+    modification type upt.
+     */
+    rpc TriggerAnyDescriptorUpdate (google.protobuf.Empty) returns (BasicResponse);
+
      /*
     Trigger a report message of the provided type.
     This manipulation of the device shall result in an msg:AbstractReport message of the provided type.

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -99,7 +99,7 @@ service DeviceService {
     Trigger a descriptor update.
     The descriptor to update has to be chosen by the device. It is expected that this manipulation succeeds
     as long as there are descriptors than can be updated.
-    This manipulation shall result in a msg:DescriptionModificationReport message with a report part with
+    This manipulation shall result in a msg:DescriptionModificationReport message with a msg:ReportPart/@ModificationType = "Upt".
     modification type upt.
      */
     rpc TriggerAnyDescriptorUpdate (google.protobuf.Empty) returns (BasicResponse);


### PR DESCRIPTION
The TriggerDescriptorUpdate manipulation requires specifying the descriptor that is to be updated. However, for most descriptor types, there are devices that do not support updating them. Also, to the best of my knowledge, there are no type of descriptor that exists in every Mdib and can be always be updated.  
Hence, when the goal is to trigger a DescriptorManipulationReport with parts of type UPT, then the only way to find a descriptor in the Mdib, which can be updated is trial and error. However, trial and error would involve calling the TriggerDescriptorUpdate manipulation quite often, which is burdensome when the manipulation has to be performed manually. 

Hence, we introduce a new manipulation TriggerAnyDescriptorUpdate which essentially does the same as TriggerDescriptorUpdate, but does not require the caller to specify the descriptor. Rather, it chooses the descriptor itself - and as long as the device has descriptos that can be updated, it should of course choose one of them.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
