### PR TITLE
new manipulation for express no metric value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- manipulation TransitionProvideValueToExpressNoValueAvailable for metrics
 - manipulation ProvideMetricValueOrSamples for metrics
 - manipulation SetSomeAlertSignalPresence for alerts
 - manipulation CreateContextStateWithAssociationAndSetOperatingMode for contexts and operations
@@ -37,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- manipulation SetNoValue
 - manipulation SetAlertSignalPresence
 - manipulation ChangeMdibSequenceId
 - manipulation SetUserConfirmableValue

--- a/src/t2iapi/metric/service.proto
+++ b/src/t2iapi/metric/service.proto
@@ -29,13 +29,6 @@ service MetricService {
       returns (BasicResponse);
 
   /*
-  Set no metric values for the provided metric handle.
-  The manipulated state can be set temporarily or persistent until a next manipulation call.
-   */
-  rpc SetNoValue (BasicHandleRequest)
-      returns (BasicResponse);
-
-  /*
   For the metric with the provided handle do the following:
    - set the @ActivationState to the provided value
    - set the pm:MetricValue/@Value resp. @Samples and confirm the value via the device ui
@@ -111,5 +104,13 @@ service MetricService {
   the static state, it shall return RESULT_NOT_SUPPORTED.
    */
   rpc ProvideMetricValueOrSamples (BasicHandleRequest)
+      returns (BasicResponse);
+
+  /*
+  For the metric with the provided handle perform the following transition:
+   - provide pm:MetricValue/@Value resp. @Samples and then
+   - express for the metric that no value is available.
+   */
+  rpc TransitionProvideValueToExpressNoValueAvailable (BasicHandleRequest)
       returns (BasicResponse);
 }


### PR DESCRIPTION
Remove manipulation SetNoValue and add a new manipulation TransitionProvideValueToExpressNoValueAvailable for metrics.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
