### PR TITLE
remove and add new context transition manipulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- manipulation TransitionFromCreateStateWithIdentificationToRemoveIdentification for contexts
+- manipulation TransitionFromCreateStateWithIdentificationToChangeIdentification for contexts
 - manipulation TransitionProvideValueToExpressNoValueAvailable for metrics
 - manipulation ProvideMetricValueOrSamples for metrics
 - manipulation SetSomeAlertSignalPresence for alerts
@@ -38,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- manipulation CreateContextStateWithAssociationAndUniqueIdentification, RemoveIdentificationOfContextState, 
+    ChangeIdentificationOfContextState
 - manipulation SetNoValue
 - manipulation SetAlertSignalPresence
 - manipulation ChangeMdibSequenceId

--- a/src/t2iapi/context/context_responses.proto
+++ b/src/t2iapi/context/context_responses.proto
@@ -25,18 +25,6 @@ message CreateContextStateWithAssociationResponse {
 }
 
 /*
-Response containing the handle of the newly created context state and its unique identification.
-In case of a PatientContextState having multiple pm:InstanceIdentifier, the @Extension and @Root shall be returned
-for the pm:InstanceIdentifier with pm:Type/@Code = MDC_ATTR_PT_ID.
- */
-message CreateContextStateWithAssociationAndUniqueIdentificationResponse {
-    BasicResponse status = 1;
-    string context_state_handle = 2;  // handle of the context state, that was created
-    string extension  = 3;  // value of the identifier (from pm:InstanceIdentifier/@Extension)
-    string root  = 4;  // value of the identifier (from pm:InstanceIdentifier/@Root)
-}
-
-/*
 Response which contains all context types supported by the DUT.
  */
 message GetSupportedContextTypesResponse {

--- a/src/t2iapi/context/service.proto
+++ b/src/t2iapi/context/service.proto
@@ -92,7 +92,7 @@ service ContextService {
   For the Context with the provided descriptor handle perform the following transition:
   - create a new associated pm:AbstractContextState instance with at least one unique pm:Identification element
     for the Context with the given descriptor handle
-  - change at least one pm:Identification element for the previously created pm:AbstractContextState.
+  - change at least one already present pm:Identification element for the previously created pm:AbstractContextState.
  */
   rpc TransitionFromCreateStateWithIdentificationToChangeIdentification (BasicHandleRequest)
       returns (CreateContextStateWithAssociationResponse);

--- a/src/t2iapi/context/service.proto
+++ b/src/t2iapi/context/service.proto
@@ -71,16 +71,6 @@ service ContextService {
 
   /*
   Create a new ContextState instance with the given ContextAssociation value for the given descriptor handle
-  and provide the unique identification.
-  The manipulated state shall be persistent until a next manipulation call. If the device is not able to maintain
-  the static state, it shall return RESULT_NOT_SUPPORTED.
-   */
-  rpc CreateContextStateWithAssociationAndUniqueIdentification(
-  t2iapi.context.CreateContextStateWithAssociationRequest)
-      returns (t2iapi.context.CreateContextStateWithAssociationAndUniqueIdentificationResponse);
-
-  /*
-  Create a new ContextState instance with the given ContextAssociation value for the given descriptor handle
   and provide at least one Identification and Validator for this ContextState.
   The manipulated state shall be persistent until a next manipulation call. If the device is not able to maintain
   the static state, it shall return RESULT_NOT_SUPPORTED.
@@ -90,22 +80,22 @@ service ContextService {
       returns (BasicResponse);
 
   /*
-  Remove at least one pm:Identification element for the pm:AbstractContextState/@Handle.
-  The manipulated state shall be persistent until a next manipulation call. If the device is not able to maintain
-  the static state, it shall return RESULT_NOT_SUPPORTED.
+  For the Context with the provided handle perform the following transition:
+  - create a new associated pm:AbstractContextState instance for the given descriptor handle and provide at least
+    one unique pm:Identification element(s)
+  - remove at least one pm:Identification element for the previous created pm:AbstractContextState.
  */
-  rpc RemoveIdentificationOfContextState(
-  t2iapi.context.ContextStateHandleRequest)
-      returns (BasicResponse);
+  rpc TransitionFromCreateStateWithIdentificationToRemoveIdentification (BasicHandleRequest)
+      returns (CreateContextStateWithAssociationResponse);
 
   /*
-  Change at least one pm:Identification element for the pm:AbstractContextState/@Handle.
-  The manipulated state shall be persistent until a next manipulation call. If the device is not able to maintain
-  the static state, it shall return RESULT_NOT_SUPPORTED.
+  For the Context with the provided handle perform the following transition:
+  - create a new associated pm:AbstractContextState instance for the given descriptor handle and provide at least
+    one unique pm:Identification element(s)
+  - change at least one pm:Identification element for the previous created pm:AbstractContextState.
  */
-  rpc ChangeIdentificationOfContextState(
-  t2iapi.context.ContextStateHandleRequest)
-      returns (BasicResponse);
+  rpc TransitionFromCreateStateWithIdentificationToChangeIdentification (BasicHandleRequest)
+      returns (CreateContextStateWithAssociationResponse);
 
   /*
   Create a new ContextState instance with the given ContextAssociation value for the given descriptor handle,

--- a/src/t2iapi/context/service.proto
+++ b/src/t2iapi/context/service.proto
@@ -80,19 +80,19 @@ service ContextService {
       returns (BasicResponse);
 
   /*
-  For the Context with the provided handle perform the following transition:
-  - create a new associated pm:AbstractContextState instance for the given descriptor handle and provide at least
-    one unique pm:Identification element(s)
-  - remove at least one pm:Identification element for the previous created pm:AbstractContextState.
+  For the Context with the provided descriptor handle perform the following transition:
+  - create a new associated pm:AbstractContextState instance with at least one unique pm:Identification element
+    for the Context with the given descriptor handle
+  - remove at least one pm:Identification element for the previously created pm:AbstractContextState.
  */
   rpc TransitionFromCreateStateWithIdentificationToRemoveIdentification (BasicHandleRequest)
       returns (CreateContextStateWithAssociationResponse);
 
   /*
-  For the Context with the provided handle perform the following transition:
-  - create a new associated pm:AbstractContextState instance for the given descriptor handle and provide at least
-    one unique pm:Identification element(s)
-  - change at least one pm:Identification element for the previous created pm:AbstractContextState.
+  For the Context with the provided descriptor handle perform the following transition:
+  - create a new associated pm:AbstractContextState instance with at least one unique pm:Identification element
+    for the Context with the given descriptor handle
+  - change at least one pm:Identification element for the previously created pm:AbstractContextState.
  */
   rpc TransitionFromCreateStateWithIdentificationToChangeIdentification (BasicHandleRequest)
       returns (CreateContextStateWithAssociationResponse);


### PR DESCRIPTION
remove manipulation CreateContextStateWithAssociationAndUniqueIdentification, RemoveIdentificationOfContextState, ChangeIdentificationOfContextState
and new manipulation TransitionFromCreateStateWithIdentificationToRemoveIdentification, TransitionFromCreateStateWithIdentificationToChangeIdentification

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
