### PR TITLE
Adapt ensemble context indicate membership with identification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TriggerAnyDescriptorUpdate manipulation
 
 ### Changed
+- semantics for the EnsembleContextIndicateMembershipWithIdentification manipulation
 - semantics for the SetMetricValuesInRange manipulation
 - semantics for the SetAlertConditionPresence manipulation
 - semantics for SetOperatingMode manipulation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - manipulation SetInvalidValue to SetIncorrectValue, changed semantics
 - semantics for SetAlertActivation, SetComponentActivation, SetAlarmSignalInactivationState, 
     SetAlertSystemNotFunctional, SetLocationDetail, RemoveAllContextStateValidators, SetContextStateAssociation,
-    CreateContextStateWithAssociation, CreateContextStateWithAssociationAndUniqueIdentification, 
-    CreateContextStateWithAssocIdentificationAndValidator, RemoveIdentificationOfContextState,
-    ChangeIdentificationOfContextState, CreateContextStateWithAssocAndSpecificValidator,
-    SetClockDevice, SetLanguage, SetNoValue, SetMetricValuesWithQualityMode
+    CreateContextStateWithAssociation, CreateContextStateWithAssocIdentificationAndValidator, 
+    CreateContextStateWithAssocAndSpecificValidator, SetClockDevice, SetLanguage, SetNoValue, 
+    SetMetricValuesWithQualityMode
 - semantics for CreateContextStateWithAssociationAndValidators manipulation
 - semantics for SetDeviceOperatingMode manipulation
 - message PartialIdentification to message PartialInstanceIdentifier

--- a/src/t2iapi/context/context_responses.proto
+++ b/src/t2iapi/context/context_responses.proto
@@ -45,10 +45,11 @@ message GetSupportedContextTypesResponse {
 }
 
 /*
-Response which contains Identification including a list of InstanceIdentifier elements
-which identify an ensemble and thus enables the caller to distinguish ensembles from each other.
+Response which contains lists of Identification objects including a list of InstanceIdentifier elements.
+Each Identification object identifies an ensemble and thus enables the caller to distinguish ensembles from each other.
+For each pm:EnsembleContextState to identify, an Identification object shall be returned.
  */
 message EnsembleContextIndicateMembershipWithIdentificationResponse {
     BasicResponse status = 1;
-    repeated PartialInstanceIdentifier identification = 2;
+    repeated Identification identification = 2;
 }

--- a/src/t2iapi/context/context_responses.proto
+++ b/src/t2iapi/context/context_responses.proto
@@ -33,7 +33,7 @@ message GetSupportedContextTypesResponse {
 }
 
 /*
-Response which contains a list of lists with pm:Identification elements. Each list if pm:Identification elements
+Response which contains a list of lists with pm:Identification elements. Each list of pm:Identification elements
 identifies a pm:EnsembleContextState and thus enables the differentiation of ensembles from each other.
  */
 message EnsembleContextIndicateMembershipWithIdentificationResponse {

--- a/src/t2iapi/context/context_responses.proto
+++ b/src/t2iapi/context/context_responses.proto
@@ -33,11 +33,10 @@ message GetSupportedContextTypesResponse {
 }
 
 /*
-Response which contains lists of Identification objects including a list of InstanceIdentifier elements.
-Each Identification object identifies an ensemble and thus enables the caller to distinguish ensembles from each other.
-For each pm:EnsembleContextState to identify, an Identification object shall be returned.
+Response which contains a list of lists with pm:Identification elements. Each list if pm:Identification elements
+identifies a pm:EnsembleContextState and thus enables the differentiation of ensembles from each other.
  */
 message EnsembleContextIndicateMembershipWithIdentificationResponse {
     BasicResponse status = 1;
-    repeated Identification identification = 2;
+    repeated IdentificationList identification_list = 3;
 }

--- a/src/t2iapi/context/service.proto
+++ b/src/t2iapi/context/service.proto
@@ -130,10 +130,10 @@ service ContextService {
 
   /*
   Indicate membership in an SDC PARTICIPANT ENSEMBLE using ensemble context state(s) that have the provided descriptor
-  handle and return a list of pm:Identification elements which identify the ensemble context states and thus enable the
-  caller to distinguish ensemble context states from each other.
-  If already one or more associated pm:EnsembleContextState(s) indicate membership, it is not needed to associate new
-  pm:EnsembleContextState(s).
+  handle and return a list of pm:Identification elements which identify the ensemble context state(s).
+  If already one or more pm:EnsembleContextState(s) indicate the membership, it is not needed to create a new
+  pm:EnsembleContextState(s). In this case it is sufficient to only return the BasicResponse and the pm:Identification
+  elements.
   The state shall be persistent until a next manipulation call. If the device is not able to maintain the static state,
   it shall return RESULT_NOT_SUPPORTED.
    */

--- a/src/t2iapi/context/service.proto
+++ b/src/t2iapi/context/service.proto
@@ -139,9 +139,13 @@ service ContextService {
       returns (BasicResponse);
 
   /*
-  Indicate membership in an SDC PARTICIPANT ENSEMBLE using an ensemble context that has the provided descriptor handle
-  and return a list of pm:Identification elements which identify an ensemble and thus enable the caller to distinguish
-  ensembles from each other.
+  Indicate membership in an SDC PARTICIPANT ENSEMBLE using ensemble context state(s) that have the provided descriptor
+  handle and return a list of pm:Identification elements which identify the ensemble context states and thus enable the
+  caller to distinguish ensemble context states from each other.
+  If already one or more associated pm:EnsembleContextState(s) indicate membership, it is not needed to associate new
+  pm:EnsembleContextState(s).
+  The state shall be persistent until a next manipulation call. If the device is not able to maintain the static state,
+  it shall return RESULT_NOT_SUPPORTED.
    */
   rpc EnsembleContextIndicateMembershipWithIdentification (BasicHandleRequest)
       returns (EnsembleContextIndicateMembershipWithIdentificationResponse);

--- a/src/t2iapi/response_types.proto
+++ b/src/t2iapi/response_types.proto
@@ -22,9 +22,15 @@ enum Result {
     RESULT_NOT_IMPLEMENTED = 3;
 }
 
+/*
+Represents pm:Identification (defined in IEEE Std 11073-10207-2017).
+*/
+message Identification {
+    repeated PartialInstanceIdentifier identification = 2;  // list of identifiers for contexts
+}
 
 /*
-Represents InstanceIdentifier (defined in IEEE Std 11073-10207-2017).
+Represents pm:InstanceIdentifier (defined in IEEE Std 11073-10207-2017).
 
 Following combinations of InstanceIdentifier/@Root and InstanceIdentifier/@Extension are allowed:
                                     +------------------------------------------------------------------------+

--- a/src/t2iapi/response_types.proto
+++ b/src/t2iapi/response_types.proto
@@ -25,8 +25,8 @@ enum Result {
 /*
 Represents pm:Identification (defined in IEEE Std 11073-10207-2017).
 */
-message Identification {
-    repeated PartialInstanceIdentifier identification = 2;  // list of identifiers for contexts
+message IdentificationList {
+    repeated PartialInstanceIdentifier identification = 1;  // list of identifiers for contexts
 }
 
 /*


### PR DESCRIPTION
Adapt description and return value of the manipulation to indicate membership in an SDC PARTICIPANT ENSEMBLE.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
