### PR TITLE
changed SetMetricStatus description 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - semantics for CreateContextStateWithAssociationAndValidators manipulation
 - semantics for SetDeviceOperatingMode manipulation
 - message PartialIdentification to message PartialInstanceIdentifier
+- semantics for SetMetricStatus manipulation
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- semantics for SetMetricStatus manipulation
 - semantics for the CalibrateMetric manipulation
 - semantics for the EnsembleContextIndicateMembershipWithIdentification manipulation
 - semantics for the SetMetricValuesInRange manipulation
@@ -39,7 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - semantics for CreateContextStateWithAssociationAndValidators manipulation
 - semantics for SetDeviceOperatingMode manipulation
 - message PartialIdentification to message PartialInstanceIdentifier
-- semantics for SetMetricStatus manipulation
 
 ### Removed
 

--- a/src/t2iapi/metric/service.proto
+++ b/src/t2iapi/metric/service.proto
@@ -84,6 +84,8 @@ service MetricService {
   /*
   Set the provided measurement, calculation or setting status for the metric of the provided handle. This is not the
   AbstractMetricState/@ActivationState, but the internal state of the device.
+  The resulting AbstractMetricState/@ActivationState shall be persistent until the next manipulation call.
+  If the device is not able to maintain the static state, it shall return RESULT_NOT_SUPPORTED.
    */
   rpc SetMetricStatus (t2iapi.metric.SetMetricStatusRequest) returns (BasicResponse);
 


### PR DESCRIPTION
Changed the description of the SetMetricStatus manipulation, since the result needs to be persistent.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
