### PR TITLE
Adapt create context state with association and validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- semantics for CreateContextStateWithAssociationAndValidators
+- semantics for CreateContextStateWithAssociationAndValidators manipulation
 - semantics for SetMetricStatus manipulation
 - semantics for the CalibrateMetric manipulation
 - message SetAlarmSignalInactivationStateRequest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     CreateContextStateWithAssociation, CreateContextStateWithAssocIdentificationAndValidator, 
     CreateContextStateWithAssocAndSpecificValidator, SetClockDevice, SetLanguage, SetNoValue, 
     SetMetricValuesWithQualityMode
-- semantics for CreateContextStateWithAssociationAndValidators manipulation
 - semantics for SetDeviceOperatingMode manipulation
 - message PartialIdentification to message PartialInstanceIdentifier
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- semantics for CreateContextStateWithAssociationAndValidators
 - semantics for SetMetricStatus manipulation
 - semantics for the CalibrateMetric manipulation
 - message SetAlarmSignalInactivationStateRequest

--- a/src/t2iapi/context/service.proto
+++ b/src/t2iapi/context/service.proto
@@ -62,8 +62,6 @@ service ContextService {
   Create a new pm:AbstractContextState instance with the given @ContextAssociation value for the given descriptor handle
   and provide at least the number of pm:Validator elements for this ContextState.
   If the number of pm:Validator elements is zero, zero pm:Validator elements shall be provided.
-  The manipulated state shall be persistent until a next manipulation call. If the device is not able to maintain
-  the static state, it shall return RESULT_NOT_SUPPORTED.
    */
   rpc CreateContextStateWithAssociationAndValidators(
   t2iapi.context.CreateContextStateWithAssociationAndValidatorsRequest)


### PR DESCRIPTION
adapt semantics for the manipulation CreateContextStateWithAssociationAndValidators. The manipulation does not expect the static state anymore

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
