### PR TITLE
Generalized triggerDescriptorUpdate manipulation to multiple ReportParts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - semantics for CreateContextStateWithAssociationAndValidators manipulation
 - semantics for SetDeviceOperatingMode manipulation
 - message PartialIdentification to message PartialInstanceIdentifier
+- generalized triggerDescriptorUpdate manipulation to multiple ReportParts
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     SetMetricValuesWithQualityMode
 - semantics for SetDeviceOperatingMode manipulation
 - message PartialIdentification to message PartialInstanceIdentifier
-- generalized triggerDescriptorUpdate manipulation to multiple ReportParts
+- generalized TriggerDescriptorUpdate manipulation to multiple ReportParts
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     SetMetricValuesWithQualityMode
 - semantics for SetDeviceOperatingMode manipulation
 - message PartialIdentification to message PartialInstanceIdentifier
-- generalized TriggerDescriptorUpdate manipulation to multiple ReportParts
+- TriggerDescriptorUpdate to request an update for an arbitrary amount of handles
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - description for allowed combinations of InstanceIdentifier/@Root and InstanceIdentifier/@Extension
 - manipulation ComponentActivationTransition
 - type hinting for python package via [types-protobuf](https://pypi.org/project/types-protobuf/)
+- TriggerAnyDescriptorUpdate manipulation
 
 ### Changed
 

--- a/src/t2iapi/device/device_requests.proto
+++ b/src/t2iapi/device/device_requests.proto
@@ -51,3 +51,10 @@ message SetBatteryUsageRequest {
                         // electrical power source
     bool use = 2;       // specifies whether the battery shall be used as the electrical power source
 }
+
+/*
+Request a DescriptionModificationReport with (multiple) Upt-ReportParts.
+*/
+message TriggerDescriptorUpdateRequest{
+    repeated string handle = 1;
+}

--- a/src/t2iapi/device/device_requests.proto
+++ b/src/t2iapi/device/device_requests.proto
@@ -54,7 +54,9 @@ message SetBatteryUsageRequest {
 
 /*
 Request a DescriptionModificationReport that fulfills the following:
-For each given handle there exists an "Upt"-ReportPart that contains an updated descriptor, whose @DescriptorHandle is equal to the given handle, and that is contained in the DescriptionModificationReport.
+
+For each given handle there exists an "Upt"-ReportPart that contains an updated descriptor, whose @DescriptorHandle
+is equal to the given handle, and that is contained in the DescriptionModificationReport.
 
 ---
 

--- a/src/t2iapi/device/device_requests.proto
+++ b/src/t2iapi/device/device_requests.proto
@@ -53,7 +53,12 @@ message SetBatteryUsageRequest {
 }
 
 /*
-Request a DescriptionModificationReport with (multiple) Upt-ReportParts.
+Request a DescriptionModificationReport that fulfills the following:
+For each given handle there exists an "Upt"-ReportPart that contains an updated descriptor, whose @DescriptorHandle is equal to the given handle, and that is contained in the DescriptionModificationReport.
+
+---
+
+Note that when no handle is given, every DescriptionModificationReport fulfills the request.
 */
 message TriggerDescriptorUpdateRequest{
     repeated string handle = 1;

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -89,11 +89,11 @@ service DeviceService {
     rpc RemoveMdsDescriptor (BasicHandleRequest) returns (BasicResponse);
 
     /*
-    Trigger a descriptor update for the provided handle.
-    This manipulation of the device shall result in a msg:DescriptionModificationReport message with a report part with
-    modification type upt.
+    Trigger a descriptor update for the provided handles.
+    This manipulation of the device shall result in a msg:DescriptionModificationReport message with one report part with
+    modification type upt for each handle provided.
      */
-    rpc TriggerDescriptorUpdate (BasicHandleRequest) returns (BasicResponse);
+    rpc TriggerDescriptorUpdate (TriggerDescriptorUpdateRequest) returns (BasicResponse);
 
     /*
     Trigger a descriptor update.

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -95,6 +95,15 @@ service DeviceService {
      */
     rpc TriggerDescriptorUpdate (BasicHandleRequest) returns (BasicResponse);
 
+    /*
+    Trigger a descriptor update.
+    The descriptor to update has to be chosen by the device. It is expected that this manipulation succeeds
+    as long as there are descriptors than can be updated.
+    This manipulation shall result in a msg:DescriptionModificationReport message containing a report part with
+    msg:ReportPart/@ModificationType = "Upt".
+     */
+    rpc TriggerAnyDescriptorUpdate (google.protobuf.Empty) returns (BasicResponse);
+
      /*
     Trigger a report message of the provided type.
     This manipulation of the device shall result in an msg:AbstractReport message of the provided type.

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -57,8 +57,6 @@ service DeviceService {
     and whose descriptors are of the given class.
     Includes handles which have been removed already and can be reinserted.
     Handles must stay the same once reinserted into the MDIB.
-    NOTE: When the requirement Biceps:R5025 is applicable to a Device, it is advisable to have at least one
-          removable descriptor that has children.
 
     Calling GetRemovableDescriptorsOfClass with descriptor_class = DESCRIPTOR_CLASS_ABSTRACT
     returns the unfiltered handles while other values for descriptor_class

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -57,6 +57,8 @@ service DeviceService {
     and whose descriptors are of the given class.
     Includes handles which have been removed already and can be reinserted.
     Handles must stay the same once reinserted into the MDIB.
+    NOTE: When the requirement Biceps:R5025 is applicable to a Device, it is advisable to have at least one
+          removable descriptor that has children.
 
     Calling GetRemovableDescriptorsOfClass with descriptor_class = DESCRIPTOR_CLASS_ABSTRACT
     returns the unfiltered handles while other values for descriptor_class

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -89,8 +89,14 @@ service DeviceService {
     rpc RemoveMdsDescriptor (BasicHandleRequest) returns (BasicResponse);
 
     /*
-    Trigger a descriptor update for the provided handles.
-    This manipulation of the device shall result in a msg:DescriptionModificationReport message in which each provided handle is present in a report part with modification type upt.
+    Trigger a DescriptionManipulationReport that fulfills the following:
+
+    For each given handle there exists an "Upt"-ReportPart that contains an updated descriptor, whose @DescriptorHandle
+    is equal to the given handle, and that is contained in the DescriptionModificationReport.
+
+    ---
+
+    Note that when no handle is given, every DescriptionModificationReport fulfills the request.
      */
     rpc TriggerDescriptorUpdate (TriggerDescriptorUpdateRequest) returns (BasicResponse);
 


### PR DESCRIPTION
In order to Fix a Defect in SDCcc's Test case for Biceps:R5025, I had to generalize this Manipulation.


# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
