### PR TITLE
New manip modify invocation effective timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- manipulation SetInvocationEffectiveTimeoutLteToThreshold for operations
+- manipulation SetInvocationEffectiveTimeoutLessThanOrEqualToThreshold for operations
 - manipulation SetModeOfOperationAndSetOperatingMode for combined settings
 - manipulation ConveyMetricDemoValues for metrics
 - manipulation SetAlertConditionAndAlertSignalActivationState for alert activation states

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- manipulation ModifyInvocationEffectiveTimeout for operations
+
 ### Changed
 
 - gRPC version to 1.58.0

--- a/src/t2iapi/operation/operation_requests.proto
+++ b/src/t2iapi/operation/operation_requests.proto
@@ -10,6 +10,7 @@ syntax = "proto3";
 package t2iapi.operation;
 
 import "t2iapi/operation/types.proto";
+import "google/protobuf/duration.proto";
 
 option java_package = "com.draeger.medical.t2iapi.operation";
 option java_outer_classname = "OperationRequests";
@@ -29,7 +30,7 @@ that is less than or equal to the requested threshold.
 message SetInvocationEffectiveTimeoutLteToThresholdRequest {
     string handle = 1;  // handle of the pm:AbstractOperationDescriptor for which the @InvocationEffectiveTimeout
                         // shall be set
-    string threshold = 2;  // threshold value for which applies that the @InvocationEffectiveTimeout is less than or
-                           // equal to this threshold value
-                           // threshold shall be of type xsd:duration
+    google.protobuf.Duration threshold = 2;  // threshold value in seconds at nanosecond resolution for which applies
+                                             // that the @InvocationEffectiveTimeout is less than or equal to this
+                                             // threshold value
 }

--- a/src/t2iapi/operation/operation_requests.proto
+++ b/src/t2iapi/operation/operation_requests.proto
@@ -27,7 +27,7 @@ message SetOperatingModeRequest {
 Request to set the @InvocationEffectiveTimeout of the pm:AbstractOperationDescriptor with the given handle to a value
 that is less than or equal to the requested threshold.
 */
-message SetInvocationEffectiveTimeoutLteToThresholdRequest {
+message SetInvocationEffectiveTimeoutLessThanOrEqualToThresholdRequest {
     string handle = 1;  // handle of the pm:AbstractOperationDescriptor for which the @InvocationEffectiveTimeout
                         // shall be set
     google.protobuf.Duration threshold = 2;  // threshold value in seconds at nanosecond resolution for which applies

--- a/src/t2iapi/operation/operation_requests.proto
+++ b/src/t2iapi/operation/operation_requests.proto
@@ -27,6 +27,8 @@ Request to set the @InvocationEffectiveTimeout of the pm:AbstractOperationDescri
 that is less than or equal to the requested threshold.
 */
 message SetInvocationEffectiveTimeoutLteToThresholdRequest {
-    string handle = 1;
-    string threshold = 2;
+    string handle = 1;  // handle of the pm:AbstractOperationDescriptor for which the @InvocationEffectiveTimeout
+                        // shall be set
+    string threshold = 2;  // threshold value for which applies that the @InvocationEffectiveTimeout is less than or
+                           // equal to this threshold value
 }

--- a/src/t2iapi/operation/operation_requests.proto
+++ b/src/t2iapi/operation/operation_requests.proto
@@ -21,3 +21,12 @@ message SetOperatingModeRequest {
     string handle = 1;
     OperatingMode operating_mode = 2;
 }
+
+/*
+Request to modify the devices descriptor, which results in setting the requested the @InvocationEffectiveTimeout for
+the pm:AbstractOperationDescriptor with the given handle.
+*/
+message ModifyInvocationEffectiveTimeoutRequest {
+    string handle = 1;
+    string invocation_effective_timeout = 2;
+}

--- a/src/t2iapi/operation/operation_requests.proto
+++ b/src/t2iapi/operation/operation_requests.proto
@@ -31,4 +31,5 @@ message SetInvocationEffectiveTimeoutLteToThresholdRequest {
                         // shall be set
     string threshold = 2;  // threshold value for which applies that the @InvocationEffectiveTimeout is less than or
                            // equal to this threshold value
+                           // threshold shall be of type xsd:duration
 }

--- a/src/t2iapi/operation/operation_requests.proto
+++ b/src/t2iapi/operation/operation_requests.proto
@@ -30,7 +30,8 @@ that is less than or equal to the requested threshold.
 message SetInvocationEffectiveTimeoutLessThanOrEqualToThresholdRequest {
     string handle = 1;  // handle of the pm:AbstractOperationDescriptor for which the @InvocationEffectiveTimeout
                         // shall be set
-    google.protobuf.Duration threshold = 2;  // threshold value in seconds at nanosecond resolution for which applies
-                                             // that the @InvocationEffectiveTimeout is less than or equal to this
-                                             // threshold value
+    google.protobuf.Duration threshold = 2;  // threshold value for which applies that the @InvocationEffectiveTimeout
+                                             // is less than or equal to this threshold value
+                                             // threshold value is represented as a count of seconds and fractions of
+                                             // seconds at nanosecond resolution
 }

--- a/src/t2iapi/operation/operation_requests.proto
+++ b/src/t2iapi/operation/operation_requests.proto
@@ -23,10 +23,10 @@ message SetOperatingModeRequest {
 }
 
 /*
-Request to modify the devices descriptor, which results in setting the requested the @InvocationEffectiveTimeout for
-the pm:AbstractOperationDescriptor with the given handle.
+Request to set the @InvocationEffectiveTimeout of the pm:AbstractOperationDescriptor with the given handle to a value
+that is less than or equal to the requested threshold.
 */
-message ModifyInvocationEffectiveTimeoutRequest {
+message SetInvocationEffectiveTimeoutLteToThresholdRequest {
     string handle = 1;
-    string invocation_effective_timeout = 2;
+    string threshold = 2;
 }

--- a/src/t2iapi/operation/service.proto
+++ b/src/t2iapi/operation/service.proto
@@ -32,8 +32,6 @@ service OperationService {
     /*
     Set the @InvocationEffectiveTimeout of the pm:AbstractOperationDescriptor with the given handle to a value that is
     less than or equal to the requested threshold.
-    The manipulated descriptor shall be persistent until a next manipulation call or an SDC operation invocation. If
-    the device is not able to maintain the static descriptor, it shall return RESULT_NOT_SUPPORTED.
     */
     rpc SetInvocationEffectiveTimeoutLteToThreshold (SetInvocationEffectiveTimeoutLteToThresholdRequest)
         returns (BasicResponse);

--- a/src/t2iapi/operation/service.proto
+++ b/src/t2iapi/operation/service.proto
@@ -31,7 +31,7 @@ service OperationService {
         returns (BasicResponse);
 
     /*
-    Update the @InvocationEffectiveTimeout of the pm:AbstractOperationDescriptor with the given handle.
+    Modify the @InvocationEffectiveTimeout of the pm:AbstractOperationDescriptor with the given handle.
     The manipulated descriptor shall be persistent until a next manipulation call. If the device is not able to maintain
     the static descriptor, it shall return RESULT_NOT_SUPPORTED.
     */

--- a/src/t2iapi/operation/service.proto
+++ b/src/t2iapi/operation/service.proto
@@ -30,10 +30,11 @@ service OperationService {
         returns (BasicResponse);
 
     /*
-    Modify the pm:AbstractOperationDescriptor with the given handle such that the @InvocationEffectiveTimeout is set to
-    the requested value.
+    Set the @InvocationEffectiveTimeout of the pm:AbstractOperationDescriptor with the given handle to a value that is
+    less than or equal to the requested threshold.
     The manipulated descriptor shall be persistent until a next manipulation call or an SDC operation invocation. If
     the device is not able to maintain the static descriptor, it shall return RESULT_NOT_SUPPORTED.
     */
-    rpc ModifyInvocationEffectiveTimeout (ModifyInvocationEffectiveTimeoutRequest) returns (BasicResponse);
+    rpc SetInvocationEffectiveTimeoutLteToThreshold (SetInvocationEffectiveTimeoutLteToThresholdRequest)
+        returns (BasicResponse);
 }

--- a/src/t2iapi/operation/service.proto
+++ b/src/t2iapi/operation/service.proto
@@ -33,6 +33,7 @@ service OperationService {
     Set the @InvocationEffectiveTimeout of the pm:AbstractOperationDescriptor with the given handle to a value that is
     less than or equal to the requested threshold.
     */
-    rpc SetInvocationEffectiveTimeoutLteToThreshold (SetInvocationEffectiveTimeoutLteToThresholdRequest)
+    rpc SetInvocationEffectiveTimeoutLessThanOrEqualToThreshold (
+        SetInvocationEffectiveTimeoutLessThanOrEqualToThresholdRequest)
         returns (BasicResponse);
 }

--- a/src/t2iapi/operation/service.proto
+++ b/src/t2iapi/operation/service.proto
@@ -32,8 +32,8 @@ service OperationService {
 
     /*
     Modify the @InvocationEffectiveTimeout of the pm:AbstractOperationDescriptor with the given handle.
-    The manipulated descriptor shall be persistent until a next manipulation call. If the device is not able to maintain
-    the static descriptor, it shall return RESULT_NOT_SUPPORTED.
+    The manipulated descriptor shall be persistent until a next manipulation call or an SDC operation invocation. If
+    the device is not able to maintain the static descriptor, it shall return RESULT_NOT_SUPPORTED.
     */
     rpc ModifyInvocationEffectiveTimeout (BasicHandleRequest) returns (BasicResponse);
 

--- a/src/t2iapi/operation/service.proto
+++ b/src/t2iapi/operation/service.proto
@@ -31,10 +31,10 @@ service OperationService {
         returns (BasicResponse);
 
     /*
-    Modify the @InvocationEffectiveTimeout of the pm:AbstractOperationDescriptor with the given handle.
+    Modify the pm:AbstractOperationDescriptor with the given handle such that the @InvocationEffectiveTimeout is set to
+    the requested value.
     The manipulated descriptor shall be persistent until a next manipulation call or an SDC operation invocation. If
     the device is not able to maintain the static descriptor, it shall return RESULT_NOT_SUPPORTED.
     */
-    rpc ModifyInvocationEffectiveTimeout (BasicHandleRequest) returns (BasicResponse);
-
+    rpc ModifyInvocationEffectiveTimeout (ModifyInvocationEffectiveTimeoutRequest) returns (BasicResponse);
 }

--- a/src/t2iapi/operation/service.proto
+++ b/src/t2iapi/operation/service.proto
@@ -10,6 +10,7 @@ syntax = "proto3";
 package t2iapi.operation;
 
 import "t2iapi/basic_responses.proto";
+import "t2iapi/basic_requests.proto";
 import "t2iapi/operation/operation_requests.proto";
 
 option java_package = "com.draeger.medical.t2iapi.operation";
@@ -28,5 +29,12 @@ service OperationService {
     */
     rpc SetOperatingMode (t2iapi.operation.SetOperatingModeRequest)
         returns (BasicResponse);
+
+    /*
+    Update the @InvocationEffectiveTimeout of the pm:AbstractOperationDescriptor with the given handle.
+    The manipulated descriptor shall be persistent until a next manipulation call. If the device is not able to maintain
+    the static descriptor, it shall return RESULT_NOT_SUPPORTED.
+    */
+    rpc ModifyInvocationEffectiveTimeout (BasicHandleRequest) returns (BasicResponse);
 
 }

--- a/src/t2iapi/operation/service.proto
+++ b/src/t2iapi/operation/service.proto
@@ -10,7 +10,6 @@ syntax = "proto3";
 package t2iapi.operation;
 
 import "t2iapi/basic_responses.proto";
-import "t2iapi/basic_requests.proto";
 import "t2iapi/operation/operation_requests.proto";
 
 option java_package = "com.draeger.medical.t2iapi.operation";


### PR DESCRIPTION
Purpose of the pull request is to add a manipulation that triggers the device to set @InvocationEffectiveTimeout less than or equal to the requested threshold.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
