### PR TITLE
Add new manipulations to indicate and end membership in an ensemble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- manipulation PhysicallyDisconnectRemovableSubsystemAfterPhysicalConnectorProvided
+- manipulation PhysicallyDisconnectRemovableSubsystemAfterPhysicalConnectorProvided for combined settings
 - manipulation SetActiveModeOfOperation for metrics
-- manipulation PhysicallyDisconnectRemovableSubsystemAfterSettingActivationStateOnOrStndBy
+- manipulation PhysicallyDisconnectRemovableSubsystemAfterSettingActivationStateOnOrStndBy for combined settings
 - manipulation RequestIndicationOfNextCalibrationTimeRequired for devices
 - manipulation IndicateTimeOfNextCalibrationToUser for devices
 - manipulation GetComponentHwVersion for devices
@@ -23,8 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - manipulation SetMdsUiLanguage for devices
 - manipulation GetMdsUiSupportedLanguages for devices
 - manipulation InsertContainmentTreeEntryForSequenceId for devices
-- manipulation IndicateMembershipInEachPossibleEnsemble
-- manipulation EndMembershipInEnsemble
+- manipulation IndicateMembershipInEachPossibleEnsemble for contexts
+- manipulation EndMembershipInEnsemble for contexts
 
 ## [4.1.0] - 2024-02-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - manipulation SetMdsUiLanguage for devices
 - manipulation GetMdsUiSupportedLanguages for devices
 - manipulation InsertContainmentTreeEntryForSequenceId for devices
+- manipulation IndicateMembershipInEachPossibleEnsemble
+- manipulation EndMembershipInEnsemble
 
 ## [4.1.0] - 2024-02-22
 

--- a/src/t2iapi/context/context_responses.proto
+++ b/src/t2iapi/context/context_responses.proto
@@ -55,7 +55,7 @@ message EnsembleContextIndicateMembershipWithIdentificationResponse {
 /*
 Response which contains a list of @Handles of pm:EnsembleContextStates. The corresponding states form a representative
 set of pm:EnsembleContextStates which if associated are sufficient to indicate membership in each possible SDC
-PARTICIPANT ENSEMBLE for a given descriptor.
+PARTICIPANT ENSEMBLE for a given pm:EnsembleContextDescriptor.
  */
 message IndicateMembershipInEachPossibleEnsembleResponse {
     BasicResponse status = 1;

--- a/src/t2iapi/context/context_responses.proto
+++ b/src/t2iapi/context/context_responses.proto
@@ -51,3 +51,13 @@ message EnsembleContextIndicateMembershipWithIdentificationResponse {
     BasicResponse status = 1;
     repeated IdentificationList identification_list = 3;
 }
+
+/*
+Response which contains a list of @Handles of pm:EnsembleContextStates. The corresponding states form a representative
+set of pm:EnsembleContextStates which if associated are sufficient to indicate membership in each possible SDC
+PARTICIPANT ENSEMBLE for a given descriptor.
+ */
+message IndicateMembershipInEachPossibleEnsembleResponse {
+    BasicResponse status = 1;
+    repeated string context_state_handle_list = 2;
+}

--- a/src/t2iapi/context/service.proto
+++ b/src/t2iapi/context/service.proto
@@ -159,6 +159,30 @@ service ContextService {
       returns (EnsembleContextIndicateMembershipWithIdentificationResponse);
 
   /*
+  Indicate membership in each intended SDC PARTICIPANT ENSEMBLE for a provided pm:EnsembleContextDescriptor by
+  associating each state contained in a representative set of pm:EnsembleContextStates of that descriptor. Return the
+  list of handles of states contained in that representative set.
+
+  The representative set of pm:EnsembleContextStates for a given pm:EnsembleContextDescriptor is a set of
+  pm:EnsembleContextStates which if associated are sufficient to indicate membership in each possible SDC PARTICIPANT
+  ENSEMBLE for that descriptor.
+
+  The state shall be persistent until a next manipulation call. If the device is not able to maintain the static state,
+  it shall return RESULT_NOT_SUPPORTED.
+   */
+  rpc IndicateMembershipInEachPossibleEnsemble (BasicHandleRequest)
+      returns (IndicateMembershipInEachPossibleEnsembleResponse);
+
+  /*
+  End membership in an SDC PARTICIPANT ENSEMBLE for a provided pm:EnsembleContextState/@Handle.
+
+  The state shall be persistent until a next manipulation call. If the device is not able to maintain the static state,
+  it shall return RESULT_NOT_SUPPORTED.
+   */
+  rpc EndMembershipInEnsemble (ContextStateHandleRequest)
+      returns (BasicResponse);
+
+  /*
   Returns all types of contexts which are supported by the DUT.
    */
   rpc GetSupportedContextTypes (google.protobuf.Empty)

--- a/src/t2iapi/context/service.proto
+++ b/src/t2iapi/context/service.proto
@@ -159,7 +159,7 @@ service ContextService {
       returns (EnsembleContextIndicateMembershipWithIdentificationResponse);
 
   /*
-  Indicate membership in each intended SDC PARTICIPANT ENSEMBLE for a provided pm:EnsembleContextDescriptor by
+  Indicate membership in each possible SDC PARTICIPANT ENSEMBLE for a provided pm:EnsembleContextDescriptor by
   associating each state contained in a representative set of pm:EnsembleContextStates of that descriptor. Return the
   list of handles of states contained in that representative set.
 


### PR DESCRIPTION
The purpose of the pull request is to add two manipulations. A first one to indicate membership in each possible SDC PARTICIPANT ENSEMBLE of a provided ensemble context descriptor and a second one end them separately by providing a related state handle.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
