### PR TITLE
add new device response for indicate next cal time

### DIFF
--- a/src/t2iapi/biceps/mdibversiongroup.proto
+++ b/src/t2iapi/biceps/mdibversiongroup.proto
@@ -1,0 +1,24 @@
+/*
+This Source Code Form is subject to the terms of the MIT License.
+Copyright (c) 2024 Draegerwerk AG & Co. KGaA.
+
+SPDX-License-Identifier: MIT
+*/
+
+syntax = "proto3";
+
+package t2iapi.biceps;
+
+option java_package = "com.draeger.medical.t2iapi.biceps";
+option java_outer_classname = "MdibVersionGroupProto";
+
+import "google/protobuf/wrappers.proto";
+
+/*
+Represents the attributeGroup MdibVersionGroup (defined in IEEE Std 11073-10207-2017).
+*/
+message MdibVersionGroup {
+    google.protobuf.UInt64Value mdib_version = 1;    // optional MdibVersion when finishing the rpc
+    google.protobuf.StringValue sequence_id = 2;     // SequenceId when finishing the rpc
+    google.protobuf.UInt64Value instance_id = 3;     // optional InstanceId when finishing the rpc
+}

--- a/src/t2iapi/biceps/mdibversiongroup.proto
+++ b/src/t2iapi/biceps/mdibversiongroup.proto
@@ -19,6 +19,6 @@ Represents the attributeGroup MdibVersionGroup (defined in IEEE Std 11073-10207-
 */
 message MdibVersionGroup {
     google.protobuf.UInt64Value mdib_version = 1;    // optional MdibVersion when finishing the rpc
-    google.protobuf.StringValue sequence_id = 2;     // SequenceId when finishing the rpc
+    string sequence_id = 2;     // SequenceId when finishing the rpc
     google.protobuf.UInt64Value instance_id = 3;     // optional InstanceId when finishing the rpc
 }

--- a/src/t2iapi/device/device_responses.proto
+++ b/src/t2iapi/device/device_responses.proto
@@ -81,5 +81,5 @@ pm:AbstractDeviceComponentDescriptor handle to indicate the time of the next cal
  */
 message IndicateTimeOfNextCalibrationToUserResponse{
     BasicResponse status = 1;   // status of the rpc
-    MdibVersionGroup mdib_version_group = 2;     // MdibVersion attributes when finishing the rpc
+    t2iapi.biceps.MdibVersionGroup mdib_version_group = 2;     // MdibVersion attributes when finishing the rpc
 }

--- a/src/t2iapi/device/device_responses.proto
+++ b/src/t2iapi/device/device_responses.proto
@@ -1,6 +1,6 @@
 /*
 This Source Code Form is subject to the terms of the MIT License.
-Copyright (c) 2022 Draegerwerk AG & Co. KGaA.
+Copyright (c) 2022, 2024 Draegerwerk AG & Co. KGaA.
 
 SPDX-License-Identifier: MIT
 */
@@ -11,6 +11,7 @@ package t2iapi.device;
 
 import "t2iapi/basic_responses.proto";
 import "t2iapi/biceps/metadata.proto";
+import "t2iapi/device/types.proto";
 
 option java_package = "com.draeger.medical.t2iapi.device";
 option java_outer_classname = "DeviceResponses";
@@ -80,6 +81,5 @@ pm:AbstractDeviceComponentDescriptor handle to indicate the time of the next cal
  */
 message IndicateTimeOfNextCalibrationToUserResponse{
     BasicResponse status = 1;   // status of the rpc
-    string sequence_id = 2;     // SequenceId when finishing the rpc
-    uint64 mdib_version = 3;    // MdibVersion when finishing the rpc
+    MdibVersion mdib_version = 2;     // MdibVersion container when finishing the rpc
 }

--- a/src/t2iapi/device/device_responses.proto
+++ b/src/t2iapi/device/device_responses.proto
@@ -73,3 +73,13 @@ message InsertContainmentTreeEntryForSequenceIdResponse{
     string handle = 2;          // descriptor handle which is representing the requested BICEPS CONTAINMENT TREE ENTRY
                                 // in the device's current MDIB
 }
+
+/*
+Response containing the BasicResponse, SequenceId and the MdibVersion for the requested
+pm:AbstractDeviceComponentDescriptor handle to indicate the time of the next calibration to the USER.
+ */
+message IndicateTimeOfNextCalibrationToUserResponse{
+    BasicResponse status = 1;   // status of the rpc
+    string sequence_id = 2;     // SequenceId when finishing the rpc
+    uint64 mdib_version = 3;    // MdibVersion when finishing the rpc
+}

--- a/src/t2iapi/device/device_responses.proto
+++ b/src/t2iapi/device/device_responses.proto
@@ -11,7 +11,7 @@ package t2iapi.device;
 
 import "t2iapi/basic_responses.proto";
 import "t2iapi/biceps/metadata.proto";
-import "t2iapi/device/types.proto";
+import "t2iapi/biceps/mdibversiongroup.proto";
 
 option java_package = "com.draeger.medical.t2iapi.device";
 option java_outer_classname = "DeviceResponses";
@@ -76,10 +76,10 @@ message InsertContainmentTreeEntryForSequenceIdResponse{
 }
 
 /*
-Response containing the BasicResponse and the MdibVersion for the requested
+Response containing the BasicResponse and the MdibVersionGroup for the requested
 pm:AbstractDeviceComponentDescriptor handle to indicate the time of the next calibration to the USER.
  */
 message IndicateTimeOfNextCalibrationToUserResponse{
     BasicResponse status = 1;   // status of the rpc
-    MdibVersion mdib_version = 2;     // MdibVersion container when finishing the rpc
+    MdibVersionGroup mdib_version_group = 2;     // MdibVersion attributes when finishing the rpc
 }

--- a/src/t2iapi/device/device_responses.proto
+++ b/src/t2iapi/device/device_responses.proto
@@ -76,7 +76,7 @@ message InsertContainmentTreeEntryForSequenceIdResponse{
 }
 
 /*
-Response containing the BasicResponse, SequenceId and the MdibVersion for the requested
+Response containing the BasicResponse and the MdibVersion for the requested
 pm:AbstractDeviceComponentDescriptor handle to indicate the time of the next calibration to the USER.
  */
 message IndicateTimeOfNextCalibrationToUserResponse{

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -181,7 +181,7 @@ service DeviceService {
     Indicate the time of the next calibration to the USER for the given pm:AbstractDeviceComponentDescriptor handle.
      */
     rpc IndicateTimeOfNextCalibrationToUser (BasicHandleRequest)
-        returns (BasicResponse);
+        returns (t2iapi.device.IndicateTimeOfNextCalibrationToUserResponse);
 
     /*
     Make available the BICEPS CONTAINMENT TREE ENTRY (as defined in IEEE Std 11073-10700-2022) that was previously

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -1,6 +1,6 @@
 /*
 This Source Code Form is subject to the terms of the MIT License.
-Copyright (c) 2022, 2024 Draegerwerk AG & Co. KGaA.
+Copyright (c) 2022, 2023, 2024 Draegerwerk AG & Co. KGaA.
 
 SPDX-License-Identifier: MIT
 */

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -1,6 +1,6 @@
 /*
 This Source Code Form is subject to the terms of the MIT License.
-Copyright (c) 2022 Draegerwerk AG & Co. KGaA.
+Copyright (c) 2022, 2024 Draegerwerk AG & Co. KGaA.
 
 SPDX-License-Identifier: MIT
 */

--- a/src/t2iapi/device/types.proto
+++ b/src/t2iapi/device/types.proto
@@ -1,6 +1,6 @@
 /*
 This Source Code Form is subject to the terms of the MIT License.
-Copyright (c) 2022 - 2024 Draegerwerk AG & Co. KGaA.
+Copyright (c) 2022, 2023, 2024 Draegerwerk AG & Co. KGaA.
 
 SPDX-License-Identifier: MIT
 */

--- a/src/t2iapi/device/types.proto
+++ b/src/t2iapi/device/types.proto
@@ -79,3 +79,11 @@ enum CalibrationState{
     CALIBRATION_STATE_CALIBRATED = 3;
     CALIBRATION_STATE_OTHER = 4;
 }
+
+/*
+Represents a container for MDIB version attributes containing the SequenceId and MdibVersion
+ */
+message MdibVersion {
+    string sequence_id = 1;     // SequenceId when finishing the rpc
+    uint64 mdib_version = 2;    // MdibVersion when finishing the rpc
+}

--- a/src/t2iapi/device/types.proto
+++ b/src/t2iapi/device/types.proto
@@ -81,9 +81,10 @@ enum CalibrationState{
 }
 
 /*
-Represents a container for MDIB version attributes containing the SequenceId and MdibVersion
+Represents a container for MDIB version attributes.
  */
 message MdibVersion {
     string sequence_id = 1;     // SequenceId when finishing the rpc
-    uint64 mdib_version = 2;    // MdibVersion when finishing the rpc
+    uint64 instance_id = 2;     // InstanceId when finishing the rpc
+    uint64 mdib_version = 3;    // MdibVersion when finishing the rpc
 }

--- a/src/t2iapi/device/types.proto
+++ b/src/t2iapi/device/types.proto
@@ -1,6 +1,6 @@
 /*
 This Source Code Form is subject to the terms of the MIT License.
-Copyright (c) 2022, 2024 Draegerwerk AG & Co. KGaA.
+Copyright (c) 2022 - 2024 Draegerwerk AG & Co. KGaA.
 
 SPDX-License-Identifier: MIT
 */
@@ -78,13 +78,4 @@ enum CalibrationState{
     CALIBRATION_STATE_RUNNING = 2;
     CALIBRATION_STATE_CALIBRATED = 3;
     CALIBRATION_STATE_OTHER = 4;
-}
-
-/*
-Represents a container for MDIB version attributes.
- */
-message MdibVersion {
-    string sequence_id = 1;     // SequenceId when finishing the rpc
-    uint64 mdib_version = 2;    // MdibVersion when finishing the rpc
-    optional google.protobuf.UInt64Value instance_id = 3;     // InstanceId when finishing the rpc
 }

--- a/src/t2iapi/device/types.proto
+++ b/src/t2iapi/device/types.proto
@@ -1,6 +1,6 @@
 /*
 This Source Code Form is subject to the terms of the MIT License.
-Copyright (c) 2022 Draegerwerk AG & Co. KGaA.
+Copyright (c) 2022, 2024 Draegerwerk AG & Co. KGaA.
 
 SPDX-License-Identifier: MIT
 */
@@ -85,6 +85,6 @@ Represents a container for MDIB version attributes.
  */
 message MdibVersion {
     string sequence_id = 1;     // SequenceId when finishing the rpc
-    uint64 instance_id = 2;     // InstanceId when finishing the rpc
-    uint64 mdib_version = 3;    // MdibVersion when finishing the rpc
+    uint64 mdib_version = 2;    // MdibVersion when finishing the rpc
+    optional google.protobuf.UInt64Value instance_id = 3;     // InstanceId when finishing the rpc
 }


### PR DESCRIPTION
Rework device manipulation IndicateTimeOfNextCalibrationToUser with new response IndicateTimeOfNextCalibrationToUserResponse.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
