### PR TITLE
add new manipulation InsertContainmentTreeEntryWithStaticHandle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - manipulation SetMdsUiLanguage for devices
 - manipulation GetMdsUiSupportedLanguages for devices
 - manipulation InsertContainmentTreeEntryForSequenceId for devices
+- manipulation InsertContainmentTreeEntryWithHandle for devices
 - manipulation to shut down and restart for devices
 - manipulation GetEnsembleIds for contexts
 - manipulation IndicateMembershipInEnsembleByEnsembleId for contexts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - manipulation SetMdsUiLanguage for devices
 - manipulation GetMdsUiSupportedLanguages for devices
 - manipulation InsertContainmentTreeEntryForSequenceId for devices
-- manipulation InsertContainmentTreeEntryWithHandle for devices
+- manipulation InsertContainmentTreeEntryWithStaticHandle for devices
 - manipulation to shut down and restart for devices
 - manipulation GetEnsembleIds for contexts
 - manipulation IndicateMembershipInEnsembleByEnsembleId for contexts

--- a/src/t2iapi/device/device_requests.proto
+++ b/src/t2iapi/device/device_requests.proto
@@ -104,11 +104,3 @@ message InsertContainmentTreeEntryForSequenceIdRequest {
     string sequence_id = 2; // @SequenceId of the devices MDIB where the requested BICEPS CONTAINMENT TREE ENTRY
                             // was seen
 }
-
-/*
-Request to make available the BICEPS CONTAINMENT TREE ENTRY (as defined in IEEE Std 11073-10700-2022) that is
-represented by the descriptor with the provided handle in the device's MDIB.
- */
-message InsertContainmentTreeEntryWithStaticHandleRequest {
-    string handle = 1;      // descriptor handle which represents the BICEPS CONTAINMENT TREE ENTRY
-}

--- a/src/t2iapi/device/device_requests.proto
+++ b/src/t2iapi/device/device_requests.proto
@@ -104,3 +104,11 @@ message InsertContainmentTreeEntryForSequenceIdRequest {
     string sequence_id = 2; // @SequenceId of the devices MDIB where the requested BICEPS CONTAINMENT TREE ENTRY
                             // was seen
 }
+
+/*
+Request to make available the BICEPS CONTAINMENT TREE ENTRY (as defined in IEEE Std 11073-10700-2022) that is
+represented by the descriptor with the provided handle in the device's MDIB.
+ */
+message InsertContainmentTreeEntryWithHandleRequest {
+    string handle = 1;      // descriptor handle which represents the BICEPS CONTAINMENT TREE ENTRY
+}

--- a/src/t2iapi/device/device_requests.proto
+++ b/src/t2iapi/device/device_requests.proto
@@ -109,6 +109,6 @@ message InsertContainmentTreeEntryForSequenceIdRequest {
 Request to make available the BICEPS CONTAINMENT TREE ENTRY (as defined in IEEE Std 11073-10700-2022) that is
 represented by the descriptor with the provided handle in the device's MDIB.
  */
-message InsertContainmentTreeEntryWithHandleRequest {
+message InsertContainmentTreeEntryWithStaticHandleRequest {
     string handle = 1;      // descriptor handle which represents the BICEPS CONTAINMENT TREE ENTRY
 }

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -244,10 +244,10 @@ service DeviceService {
   - InsertContainmentTreeEntryWithStaticHandle with handle "metric_1" is executed
   - no further action from the device is required
 
-   Example 3: the requested Channel is not known for the device:
-  - Channel with the handle "channel_a" is not present in the devices current MDIB
-  - InsertContainmentTreeEntryWithStaticHandle with handle "channel_a" is executed
-  - GRPC Status Code INVALID_ARGUMENT is returned since the requested Channel is unknown for the device
+   Example 3: the requested descriptor is not known for the device:
+  - descriptor with the handle "some_channel" is not present in the devices current MDIB and no such descriptor can exist in the devices MDIB
+  - InsertContainmentTreeEntryWithStaticHandle with handle "some_channel" is executed
+  - GRPC Status Code INVALID_ARGUMENT is returned since the requested entity is unknown for the device
    */
   rpc InsertContainmentTreeEntryWithStaticHandle (BasicHandleRequest)
       returns (BasicResponse);

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -242,7 +242,7 @@ service DeviceService {
   - InsertContainmentTreeEntryWithStaticHandle with handle metric_1 is executed
   - no further action from the device is required
    */
-  rpc InsertContainmentTreeEntryWithStaticHandle (InsertContainmentTreeEntryWithStaticHandleRequest)
+  rpc InsertContainmentTreeEntryWithStaticHandle (BasicHandleRequest)
       returns (BasicResponse);
 
     /*

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -224,6 +224,28 @@ service DeviceService {
         returns (InsertContainmentTreeEntryForSequenceIdResponse);
 
     /*
+    Make available the BICEPS CONTAINMENT TREE ENTRY (as defined in IEEE Std 11073-10700-2022) that is represented by
+    the provided handle in the device's MDIB. If the BICEPS CONTAINMENT TREE ENTRY is absent in the current MDIB,
+    it shall be inserted. If the BICEPS CONTAINMENT TREE ENTRY is already present in the current MDIB no further
+    action is required.
+
+    Hint: This manipulation is only applicable for devices which use static handles for descriptors over all
+    MDIB @SequenceID's.
+
+    Example 1: inserting the MDS into the current MDIB:
+    - devices is able to present a MDS with the handle mds1 which is currently not present in devices MDIB
+    - InsertContainmentTreeEntry with handle mds1 is executed
+    - MDS with the handle mds1 is inserted into the device's current MDIB
+    - no further action from the device is required
+
+    Example 2: Metric is already present in the current MDIB:
+    - Metric with the handle "metric_1" is already present in the devices current MDIB
+    - InsertContainmentTreeEntry with handle metric_1 is executed
+    - no further action from the device is required
+     */
+    rpc InsertContainmentTreeEntryWithHandle(InsertContainmentTreeEntryWithHandleRequest) returns (BasicResponse);
+
+    /*
     Shut down the device gracefully and then restart it. When restarting, the device should have a new
     pm:MdibVersionGroup/@SequenceId.
      */

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -223,27 +223,27 @@ service DeviceService {
     rpc InsertContainmentTreeEntryForSequenceId (InsertContainmentTreeEntryForSequenceIdRequest)
         returns (InsertContainmentTreeEntryForSequenceIdResponse);
 
-    /*
-    Make available the BICEPS CONTAINMENT TREE ENTRY (as defined in IEEE Std 11073-10700-2022) that is represented by
-    the provided handle in the device's MDIB. If the BICEPS CONTAINMENT TREE ENTRY is absent in the current MDIB,
-    it shall be inserted. If the BICEPS CONTAINMENT TREE ENTRY is already present in the current MDIB no further
-    action is required.
+  /*
+  This manipulation is only applicable for devices which use static handles for descriptors across all MDIB
+  @SequenceID's.
 
-    Hint: This manipulation is only applicable for devices which use static handles for descriptors over all
-    MDIB @SequenceID's.
+  Make available the BICEPS CONTAINMENT TREE ENTRY (as defined in IEEE Std 11073-10700-2022) that is represented by the
+  provided handle in the device's MDIB. If the BICEPS CONTAINMENT TREE ENTRY is absent in the current MDIB, it shall be
+  inserted. If the BICEPS CONTAINMENT TREE ENTRY is already present in the current MDIB no further action is required.
 
-    Example 1: inserting the MDS into the current MDIB:
-    - devices is able to present a MDS with the handle mds1 which is currently not present in devices MDIB
-    - InsertContainmentTreeEntry with handle mds1 is executed
-    - MDS with the handle mds1 is inserted into the device's current MDIB
-    - no further action from the device is required
+  Example 1: inserting the MDS into the current MDIB:
+  - devices is able to present a MDS with the handle mds1 which is currently not present in devices MDIB
+  - InsertContainmentTreeEntryWithStaticHandle with handle mds1 is executed
+  - MDS with the handle mds1 is inserted into the device's current MDIB
+  - no further action from the device is required
 
-    Example 2: Metric is already present in the current MDIB:
-    - Metric with the handle "metric_1" is already present in the devices current MDIB
-    - InsertContainmentTreeEntry with handle metric_1 is executed
-    - no further action from the device is required
-     */
-    rpc InsertContainmentTreeEntryWithHandle(InsertContainmentTreeEntryWithHandleRequest) returns (BasicResponse);
+  Example 2: Metric is already present in the current MDIB:
+  - Metric with the handle "metric_1" is already present in the devices current MDIB
+  - InsertContainmentTreeEntryWithStaticHandle with handle metric_1 is executed
+  - no further action from the device is required
+   */
+  rpc InsertContainmentTreeEntryWithStaticHandle (InsertContainmentTreeEntryWithStaticHandleRequest)
+      returns (BasicResponse);
 
     /*
     Shut down the device gracefully and then restart it. When restarting, the device should have a new

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -224,8 +224,10 @@ service DeviceService {
         returns (InsertContainmentTreeEntryForSequenceIdResponse);
 
   /*
-  This manipulation is only applicable for devices which use static handles for descriptors across all MDIB
-  @SequenceID's.
+  This manipulation is only applicable for devices which use static handles for descriptors across all sequences of
+  MDIB's. If the device under test does not support static handles for descriptors, it shall return the GRPC Status Code
+  UNIMPLEMENTED. If the request contains a handle that is unknown for the device, it shall return GRPC Status Code
+  INVALID_ARGUMENT.
 
   Make available the BICEPS CONTAINMENT TREE ENTRY (as defined in IEEE Std 11073-10700-2022) that is represented by the
   provided handle in the device's MDIB. If the BICEPS CONTAINMENT TREE ENTRY is absent in the current MDIB, it shall be
@@ -239,8 +241,13 @@ service DeviceService {
 
   Example 2: Metric is already present in the current MDIB:
   - Metric with the handle "metric_1" is already present in the devices current MDIB
-  - InsertContainmentTreeEntryWithStaticHandle with handle metric_1 is executed
+  - InsertContainmentTreeEntryWithStaticHandle with handle "metric_1" is executed
   - no further action from the device is required
+
+   Example 3: the requested Channel is not known for the device:
+  - Channel with the handle "channel_a" is not present in the devices current MDIB
+  - InsertContainmentTreeEntryWithStaticHandle with handle "channel_a" is executed
+  - GRPC Status Code INVALID_ARGUMENT is returned since the requested Channel is unknown for the device
    */
   rpc InsertContainmentTreeEntryWithStaticHandle (BasicHandleRequest)
       returns (BasicResponse);


### PR DESCRIPTION
Introduce a new manipulation to insert CONTAINMENT TREE ENTRY with the provided handle

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
