### PR TITLE
add manipulation for productionSpecification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- manipulation RemoveProductionSpecificationElement for devices
+- manipulation ChangeProductionSpecificationElement for devices
+- manipulation InsertProductionSpecificationElement for devices
 - manipulation SetMdsOperatingMode for devices
 - manipulation TransitionAccuracyFromWithinLimitsToBelowSpecifiedLimits for metrics
 - manipulation DisplayMetricWithDifferentUnit for metrics

--- a/src/t2iapi/device/device_responses.proto
+++ b/src/t2iapi/device/device_responses.proto
@@ -1,6 +1,6 @@
 /*
 This Source Code Form is subject to the terms of the MIT License.
-Copyright (c) 2022, 2024 Draegerwerk AG & Co. KGaA.
+Copyright (c) 2022, 2024, 2025 Draegerwerk AG & Co. KGaA.
 
 SPDX-License-Identifier: MIT
 */
@@ -82,4 +82,14 @@ pm:AbstractDeviceComponentDescriptor handle to indicate the time of the next cal
 message IndicateTimeOfNextCalibrationToUserResponse{
     BasicResponse status = 1;   // status of the rpc
     t2iapi.biceps.MdibVersionGroup mdib_version_group = 2;     // MdibVersion attributes when finishing the rpc
+}
+
+/*
+Response containing the BasicResponse and the (new) handle of the descriptor for which a pm:ProductionSpecification
+element was changed, removed or inserted.
+ */
+message ProductionSpecificationElementResponse {
+    BasicResponse status = 1;
+    string handle = 2;  // (new) handle of the descriptor for which a pm:ProductionSpecification was changed, removed or
+                        // inserted
 }

--- a/src/t2iapi/device/device_responses.proto
+++ b/src/t2iapi/device/device_responses.proto
@@ -86,7 +86,9 @@ message IndicateTimeOfNextCalibrationToUserResponse{
 
 /*
 Response containing the BasicResponse and the (new) handle of the descriptor for which a pm:ProductionSpecification
-element was changed, removed or inserted.
+element was changed, removed or inserted. The requirement IEEE Std 11073-10701-2022 TR1949 expects a new
+pm:MdibVersionGroup/@SequenceId after a change of pm:ProductionSpecification, therefore the potentially
+changed handle of the descriptor in the new @SequenceId is required.
  */
 message ProductionSpecificationElementResponse {
     BasicResponse status = 1;

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -275,4 +275,22 @@ service DeviceService {
     It is allowed to provide the EXTENSION(s) sequentially.
      */
     rpc ProvideExtensionElements (google.protobuf.Empty) returns (BasicResponse);
+
+    /*
+    Request to remove a pm:ProductionSpecification element of the given descriptor handle.
+     */
+    rpc RemoveProductionSpecificationElement (BasicHandleRequest)
+        returns (BasicResponse);
+
+    /*
+    Request to change a pm:ProductionSpecification element of the given descriptor handle.
+     */
+    rpc ChangeProductionSpecificationElement (BasicHandleRequest)
+        returns (BasicResponse);
+
+    /*
+    Request to insert a pm:ProductionSpecification element of the given descriptor handle.
+     */
+    rpc InsertProductionSpecificationElement (BasicHandleRequest)
+        returns (BasicResponse);
 }

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -277,19 +277,19 @@ service DeviceService {
     rpc ProvideExtensionElements (google.protobuf.Empty) returns (BasicResponse);
 
     /*
-    Request to remove a pm:ProductionSpecification element of the given descriptor handle.
+    Request to remove a pm:ProductionSpecification element of the given descriptor represented by the provided handle.
      */
     rpc RemoveProductionSpecificationElement (BasicHandleRequest)
         returns (t2iapi.device.ProductionSpecificationElementResponse);
 
     /*
-    Request to change a pm:ProductionSpecification element of the given descriptor handle.
+    Request to change a pm:ProductionSpecification element of the given descriptor represented by the provided handle.
      */
     rpc ChangeProductionSpecificationElement (BasicHandleRequest)
         returns (t2iapi.device.ProductionSpecificationElementResponse);
 
     /*
-    Request to insert a pm:ProductionSpecification element of the given descriptor handle.
+    Request to insert a pm:ProductionSpecification element into the given descriptor represented by the provided handle.
      */
     rpc InsertProductionSpecificationElement (BasicHandleRequest)
         returns (t2iapi.device.ProductionSpecificationElementResponse);

--- a/src/t2iapi/device/service.proto
+++ b/src/t2iapi/device/service.proto
@@ -280,17 +280,17 @@ service DeviceService {
     Request to remove a pm:ProductionSpecification element of the given descriptor handle.
      */
     rpc RemoveProductionSpecificationElement (BasicHandleRequest)
-        returns (BasicResponse);
+        returns (t2iapi.device.ProductionSpecificationElementResponse);
 
     /*
     Request to change a pm:ProductionSpecification element of the given descriptor handle.
      */
     rpc ChangeProductionSpecificationElement (BasicHandleRequest)
-        returns (BasicResponse);
+        returns (t2iapi.device.ProductionSpecificationElementResponse);
 
     /*
     Request to insert a pm:ProductionSpecification element of the given descriptor handle.
      */
     rpc InsertProductionSpecificationElement (BasicHandleRequest)
-        returns (BasicResponse);
+        returns (t2iapi.device.ProductionSpecificationElementResponse);
 }


### PR DESCRIPTION
Add new manipulation for devices to insert, change and remove a productionSpecification element

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
