### PR TITLE
set write permission for deploy step

### DIFF
--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -103,6 +103,8 @@ jobs:
   deploy-maven-central:
     runs-on: ubuntu-latest
     needs: run-tests-java17
+    permissions:
+      contents: write
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The purpose of the pull request is to set the write permissions for the deploy on maven central job, since the action "softprops/action-gh-release@v1" is not allowed to attach artifacts to github release.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
